### PR TITLE
able to persist storage with localStorage and Persistor with Redux

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-scripts": "3.3.1",
     "redux": "^4.0.5",
     "redux-logger": "^3.0.6",
+    "redux-persist": "^6.0.0",
     "reselect": "^4.0.0"
   },
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom'
-
 import { Provider } from 'react-redux'
-import store from './redux/store'
+import { PersistGate } from 'redux-persist/integration/react'
+
+
+import {store, persistor} from './redux/store'
 
 
 
@@ -14,7 +16,9 @@ import './index.css';
 ReactDOM.render(
 <Provider store={store}>
     <BrowserRouter>
-        <App />
+        <PersistGate persistor={persistor}>
+            <App />
+        </PersistGate>
     </BrowserRouter>
 </Provider>,
 document.getElementById('root')

--- a/src/redux/root-reducer.js
+++ b/src/redux/root-reducer.js
@@ -1,9 +1,19 @@
 import { combineReducers } from 'redux';
+import { persistReducer } from 'redux-persist'
+import storage from 'redux-persist/lib/storage'
 
 import userReducer from './user/user.reducer';
 import cartReducer from './cart/cart.reducer';
 
-export default combineReducers({
+const persistConfig = {
+    key: 'root',
+    storage,
+    whitelist: ['cart']
+};
+
+const rootReducer = combineReducers({
     user: userReducer,
     cart: cartReducer
-})
+});
+
+export default persistReducer(persistConfig, rootReducer);

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,11 +1,14 @@
 import { createStore, applyMiddleware } from 'redux';
+import { persistStore } from 'redux-persist'
 import logger from 'redux-logger';
+
 
 import rootReducer from './root-reducer'
 
 const middlewares = [logger];
 
-const store = createStore(rootReducer, applyMiddleware(...middlewares))
+export const store = createStore(rootReducer, applyMiddleware(...middlewares))
 
+export const persistor = persistStore(store);
 
-export default store;
+export default { store, persistor };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9430,6 +9430,11 @@ redux-logger@^3.0.6:
   dependencies:
     deep-diff "^0.3.5"
 
+redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
+
 redux@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"


### PR DESCRIPTION
Using yarn add redux-persist, we bring in a library that allows us to have a persist method for our Redux state. In out store JS file, we bring in the persistStore Method from redux-persist and createStore from redux, we then create a variable [store] that we pass our rootReducer and middlewares through. we then create a variable [persistor] that we use the persistStore method and pass our variable store through. we then export store and persistor. In our root-reducer file we import the persistReducer method from redux-persist and import storage from the 'redux-persist/lib/storage' library. we then create a variable [rootReducer] and have that be our former exported comineReducers method. we also create a variable [persistConfig] and create an object that has our key, storage object, and whitelist which is our 'cart'. we then export out persistReducer methode and pas out persistConfig and rootReducer through it. In our Index.js we have to import the PersistGate method from 'redux-persist/integration/react' and also import store from our redux/store store along with persistor. We then wrap the Class App with PersistGate and pass the props of persistor through PersistGate. 